### PR TITLE
Copy edits to the status text for filters

### DIFF
--- a/lib/client/elements/dartisans_filter_status.html
+++ b/lib/client/elements/dartisans_filter_status.html
@@ -15,8 +15,8 @@
         <core-label vertical layout>
           <div vertical layout>
             <div style="margin-left: 20px;" >{{currentSelectionNb}} / {{nbAllDartisans}} Dartisans</div>
-            <div hidden?="{{!filteredBySearchCriterias}}" style="margin-left: 40px;" >some search creterias are active</div>
-            <div hidden?="{{!filteredByMap}}" style="margin-left: 40px;" >location filter is active</div>
+            <div hidden?="{{!filteredBySearchCriterias}}" style="margin-left: 40px;" >Some search criteria are active</div>
+            <div hidden?="{{!filteredByMap}}" style="margin-left: 40px;" >Map filter is active</div>
           </div>
         </core-label> 
   </template>


### PR DESCRIPTION
Besides minor copy edits, I changed "location" to "Map" so the help would match the UI text, making it a little easier to figure out how to change the filter.

NOTE: I get the search criteria text whether I have a map filter set, even though I haven't specified search criteria.
